### PR TITLE
x/migration: add NewFSSource

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AlexisMontagne @upfluence/golang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,10 @@ on:
 jobs:
   test:
     name: Run Tests
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        go: [ '1.16.x', '1.15.x', '1.14.x' ]
     services:
       cassandra:
         image: upfluence/cassandra
@@ -26,12 +27,11 @@ jobs:
           --health-retries 5
         ports:
           - 9042:9042
-
     steps:
-      - name: Install Go
+      - name: Install Go ${{ matrix.go }}
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: ${{ matrix.go }}
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
       - name: Check out code
         uses: actions/checkout@v1
       - name: golanci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upfluence/cql
 
-go 1.14
+go 1.16
 
 require (
 	github.com/gocql/gocql v0.0.0-20201215165327-e49edf966d90

--- a/x/migration/fs_source.go
+++ b/x/migration/fs_source.go
@@ -1,0 +1,41 @@
+// +build go1.16
+
+package migration
+
+import (
+	"io/fs"
+
+	"github.com/upfluence/log"
+)
+
+func MustFSSource(src fs.FS, logger log.Logger) Source {
+	s, err := NewFSSource(src, logger)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return s
+}
+
+func NewFSSource(src fs.FS, logger log.Logger) (Source, error) {
+	files, err := fs.ReadDir(src, ".")
+
+	if err != nil {
+		return nil, err
+	}
+
+	vs := make([]string, len(files))
+
+	for i, f := range files {
+		vs[i] = f.Name()
+	}
+
+	return NewStaticSource(
+		vs,
+		func(file string) ([]byte, error) {
+			return fs.ReadFile(src, file)
+		},
+		logger,
+	), nil
+}

--- a/x/migration/fs_source_test.go
+++ b/x/migration/fs_source_test.go
@@ -1,0 +1,46 @@
+// +build go1.16
+
+package migration
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/upfluence/log"
+)
+
+func TestFSSource(t *testing.T) {
+	var (
+		ctx = context.Background()
+		fs  = fstest.MapFS{
+			"3_final.down.cql": &fstest.MapFile{Data: []byte("bar")},
+			"2_initial.up.cql": &fstest.MapFile{Data: []byte("foo")},
+			"3_final.up.cql":   &fstest.MapFile{Data: []byte("bar")},
+		}
+	)
+
+	s, err := NewFSSource(fs, log.NewLogger(log.WithSink(sink{})))
+	require.NoError(t, err)
+
+	m, err := s.First(ctx)
+	require.NoError(t, err)
+
+	assertMigration(t, m, 2, "foo", "")
+
+	_, id, _ := s.Next(ctx, 2)
+
+	assert.Equal(t, uint(3), id)
+
+	m, _ = s.Get(ctx, id)
+	assertMigration(t, m, 3, "bar", "bar")
+
+	ok, _, _ := s.Prev(ctx, 2)
+	assert.False(t, ok)
+
+	ok, _, err = s.Next(ctx, 3)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a new migration source constructor based on go1.16 [io/fs](https://tip.golang.org/pkg/io/fs/) package.
This open the road to using https://golang.org/pkg/embed/ for our migrations and remove gobindata generated files.

Instead of passing logger down and only logging issues, I chose to return errors explicitly and use the `Must` pattern which makes the app panic if it detects an error. As in that case it's build time issues, I do believe it's more suited. WDYT ?

Also adds @AlexisMontagne and @upfluence/golang as maintainers.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled